### PR TITLE
This file does not need `address payable`

### DIFF
--- a/contracts/lifecycle/TokenDestructible.sol
+++ b/contracts/lifecycle/TokenDestructible.sol
@@ -21,13 +21,12 @@ contract TokenDestructible is Ownable {
    * @notice The called token contracts could try to re-enter this contract. Only
    supply token contracts you trust.
    */
-  function destroy(address payable[] memory tokens) onlyOwner public {
+  function destroy(ERC20Basic[] memory tokens) onlyOwner public {
 
     // Transfer tokens to owner
     for (uint256 i = 0; i < tokens.length; i++) {
-      ERC20Basic token = ERC20Basic(tokens[i]);
-      uint256 balance = token.balanceOf(address(this));
-      token.transfer(owner, balance);
+      uint256 balance = tokens[i].balanceOf(address(this));
+      tokens[i].transfer(owner, balance);
     }
 
     // Transfer Eth to owner and terminate contract


### PR DESCRIPTION
After some people complained about ``address payable`` I investigated how often it actually needs to be used. My guess would be "not that ofter", because if you use the withdraw pattern, you usually call `msg.sender.transfer(amount)` instead of something like `owers[i].transfer(amount)`.

I checked the openzeppelin code and found quite some `address payable`, but I actually think that quite some of them could be removed, like this one.